### PR TITLE
Add caretaker's UpdateMenu and ViewMenu pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
     "@phosphor-icons/react": "^2.1.7",
     "@reduxjs/toolkit": "^2.2.7",
     "axios": "^1.7.7",
+    "moment": "^2.30.1",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
+    "react-datepicker": "^7.4.0",
     "react-dom": "^18.3.1",
     "react-redux": "^9.1.2",
     "react-router-dom": "^6.26.2"

--- a/package.json
+++ b/package.json
@@ -13,11 +13,16 @@
     "format": "prettier --write \"src/**/*.{js,jsx}\""
   },
   "dependencies": {
-    "@mantine/core": "^7.12.2",
+    "@mantine/core": "^7.13.2",
+    "@mantine/dates": "^7.13.2",
+    "@mantine/hooks": "^7.13.2",
     "@mantine/notifications": "^7.13.2",
     "@phosphor-icons/react": "^2.1.7",
     "@reduxjs/toolkit": "^2.2.7",
+    "@tabler/icons-react": "^3.19.0",
     "axios": "^1.7.7",
+    "date-fns": "^4.1.0",
+    "lucide-react": "^0.453.0",
     "moment": "^2.30.1",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import Profile from "./Modules/Profile/profile";
 import LoginPage from "./pages/login";
 import ForgotPassword from "./pages/forgotPassword";
 import AcademicPage from "./Modules/Academic/index";
+import MessPage from "./Modules/Mess/pages/index";
 import ValidateAuth from "./helper/validateauth";
 
 export default function App() {
@@ -37,6 +38,14 @@ export default function App() {
           element={
             <Layout>
               <AcademicPage />
+            </Layout>
+          }
+        />
+        <Route
+          path="/mess"
+          element={
+            <Layout>
+              <MessPage />
             </Layout>
           }
         />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { MantineProvider } from "@mantine/core";
+import { DatesProvider } from '@mantine/dates';
 import "@mantine/core/styles.css";
 import { Route, Routes, Navigate, useLocation } from "react-router-dom";
 import { Notifications } from "@mantine/notifications";
@@ -15,6 +16,7 @@ export default function App() {
   const location = useLocation();
   return (
     <MantineProvider>
+       <DatesProvider>
       <Notifications
         position="top-right"
         zIndex={1000}
@@ -60,6 +62,7 @@ export default function App() {
         <Route path="/accounts/login" element={<LoginPage />} />
         <Route path="/reset-password" element={<ForgotPassword />} />
       </Routes>
+      </DatesProvider>
     </MantineProvider>
   );
 }

--- a/src/Modules/Mess/components/BillBaseAndExcelUpload.jsx
+++ b/src/Modules/Mess/components/BillBaseAndExcelUpload.jsx
@@ -1,0 +1,112 @@
+import React, { useState } from "react";
+import {
+  TextInput,
+  Button,
+  Container,
+  Title,
+  Paper,
+  Group,
+  FileInput,
+} from "@mantine/core"; // Import Mantine components
+// import { IconUpload } from "@phosphor-icons/react"; // Import Phosphor Upload icon
+
+function BillBase() {
+  const [amount, setAmount] = useState(""); // State for base amount
+  const [file, setFile] = useState(null); // State for file upload
+
+  // Function to handle the update of the base amount (for demo purposes)
+  const updateBaseAmount = (event) => {
+    event.preventDefault();
+    alert(`Updated base amount to: Rs. ${amount}`); // Alert to simulate update
+  };
+
+  // Function to handle the file upload (for demo purposes)
+  const uploadFile = (event) => {
+    event.preventDefault();
+    if (file) {
+      alert(`File uploaded: ${file.name}`); // Alert to simulate file upload
+    } else {
+      alert("Please select a file to upload."); // Alert if no file selected
+    }
+  };
+
+  return (
+    <Container
+      size="lg"
+      style={{
+        maxWidth: "800px", // Limit maximum width to 800px
+        width: "570px", // Set the width to a fixed value (e.g., 800px)
+        marginTop: "30px",
+      }} // Container settings
+    >
+      <Paper shadow="md" radius="md" p="xl" withBorder>
+        <Title order={2} align="center" mb="lg" style={{ color: "#1c7ed6" }}>
+          Monthly Bill Base
+        </Title>
+
+        {/* Update Base Amount Form */}
+        <form onSubmit={updateBaseAmount}>
+          <Group direction="column" grow spacing="lg">
+            <div className="two fields">
+              <TextInput
+                label="Current Base Amount"
+                placeholder="Enter the new base amount"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                type="number" // Numeric input
+                required
+                radius="md"
+                mb="lg"
+              />
+              <div style={{ marginTop: "10px" }}>
+                {" "}
+                {/* Adjust marginTop as needed */}
+                <Button
+                  className="ui primary button right floated"
+                  type="submit"
+                >
+                  Update Base Amount
+                </Button>
+              </div>
+            </div>
+          </Group>
+        </form>
+
+        <hr />
+
+        {/* Upload Monthly Bill Form */}
+        <form onSubmit={uploadFile}>
+          <Group
+            direction="column"
+            grow
+            spacing="lg"
+            style={{ marginTop: "10px" }}
+          >
+            <FileInput
+              label="Upload Monthly Bill"
+              placeholder="Choose Excel file"
+              value={file}
+              onChange={setFile} // Directly update file state
+              accept=".xlsx,.xls"
+              required
+              styles={{ input: { width: "100%" } }} // Set full width
+            />
+            <div style={{ marginTop: "10px" }}>
+              {" "}
+              {/* Adjust marginTop as needed */}
+              <Button
+                className="ui primary fluid button"
+                type="submit"
+                style={{ maxWidth: "10rem", marginTop: "10px" }}
+              >
+                Update Bills
+              </Button>
+            </div>
+          </Group>
+        </form>
+      </Paper>
+    </Container>
+  );
+}
+
+export default BillBase;

--- a/src/Modules/Mess/components/CaretakerIndex.jsx
+++ b/src/Modules/Mess/components/CaretakerIndex.jsx
@@ -1,0 +1,136 @@
+import {
+  Button,
+  Container,
+  Flex,
+  Grid,
+  Loader,
+  Tabs,
+  Text,
+} from "@mantine/core";
+import { CaretCircleLeft, CaretCircleRight } from "@phosphor-icons/react";
+import { useRef, useState } from "react";
+import CustomBreadcrumbs from "../../../components/Breadcrumbs.jsx";
+import classes from "../styles/messModule.module.css";
+import UpdateSemDates from "./UpdateSemesterDates.jsx";
+import MessActivities from "./MessActivities.jsx";
+
+// Import all the components here
+//   import ComplaintForm from "./components/ComplaintForm.jsx";
+
+function Caretaker() {
+  const [activeTab, setActiveTab] = useState("0");
+  const tabsListRef = useRef(null);
+
+  const tabItems = [
+    { title: "View FeedBack | Statistics" },
+    { title: "Respond to rebate requests" },
+    { title: "Reg/Dereg/UpdatePayment Requests" },
+    { title: "View Special Food requests" },
+    { title: "View Menu" },
+    { title: "Mess Activities" },
+    { title: "View Registrations" },
+    { title: "Update Menu" },
+    { title: "Update Sem Dates" },
+  ];
+
+  const handleTabChange = (direction) => {
+    const newIndex =
+      direction === "next"
+        ? Math.min(+activeTab + 1, tabItems.length - 1)
+        : Math.max(+activeTab - 1, 0);
+    setActiveTab(String(newIndex));
+    tabsListRef.current.scrollBy({
+      left: direction === "next" ? 50 : -50,
+      behavior: "smooth",
+    });
+  };
+
+  // Function to render content based on active tab
+  const renderTabContent = () => {
+    switch (activeTab) {
+      case "0":
+        return <p>View Feedback | Statistics</p>;
+      case "1":
+        return <p>Respond to rebate requests</p>;
+      case "2":
+        return <p>Reg/Dereg/UpdatePayment Requests</p>;
+      case "3":
+        return <p>View Special Food requests</p>;
+      case "4":
+        return <p>View Menu</p>;
+      case "5":
+        return <MessActivities />;
+      case "6":
+        return <p>Mess Registrations</p>;
+      case "7":
+        return <p>Update Menu</p>;
+      case "8":
+        return <UpdateSemDates />;
+      default:
+        return <Loader />;
+    }
+  };
+
+  return (
+    <>
+      {/* Navbar contents */}
+      <CustomBreadcrumbs />
+      <Flex justify="space-between" align="center" mt="lg">
+        <Flex justify="flex-start" align="center" gap="1rem" mt="1.5rem">
+          <Button
+            onClick={() => handleTabChange("prev")}
+            variant="default"
+            p={0}
+            style={{ border: "none" }}
+          >
+            <CaretCircleLeft
+              className={classes.fusionCaretCircleIcon}
+              weight="light"
+            />
+          </Button>
+
+          <div className={classes.fusionTabsContainer} ref={tabsListRef}>
+            <Tabs value={activeTab} onChange={setActiveTab}>
+              <Tabs.List style={{ display: "flex", flexWrap: "nowrap" }}>
+                {tabItems.map((item, index) => (
+                  <Tabs.Tab
+                    value={`${index}`}
+                    key={index}
+                    className={
+                      activeTab === `${index}`
+                        ? classes.fusionActiveRecentTab
+                        : ""
+                    }
+                  >
+                    <Flex gap="4px">
+                      <Text>{item.title}</Text>
+                    </Flex>
+                  </Tabs.Tab>
+                ))}
+              </Tabs.List>
+            </Tabs>
+          </div>
+
+          <Button
+            onClick={() => handleTabChange("next")}
+            variant="default"
+            p={0}
+            style={{ border: "none" }}
+          >
+            <CaretCircleRight
+              className={classes.fusionCaretCircleIcon}
+              weight="light"
+            />
+          </Button>
+        </Flex>
+      </Flex>
+
+      {/* Main content */}
+      <Grid>
+        <Container>{renderTabContent()}</Container>
+      </Grid>
+    </>
+  );
+}
+
+export default Caretaker;

--- a/src/Modules/Mess/components/CaretakerIndex.jsx
+++ b/src/Modules/Mess/components/CaretakerIndex.jsx
@@ -13,6 +13,9 @@ import CustomBreadcrumbs from "../../../components/Breadcrumbs.jsx";
 import classes from "../styles/messModule.module.css";
 import UpdateSemDates from "./UpdateSemesterDates.jsx";
 import MessActivities from "./MessActivities.jsx";
+import ViewMenu from "./ViewMenu.jsx";
+import UpdateMenu from "./UpdateMenu.jsx";
+
 
 // Import all the components here
 //   import ComplaintForm from "./components/ComplaintForm.jsx";
@@ -57,13 +60,13 @@ function Caretaker() {
       case "3":
         return <p>View Special Food requests</p>;
       case "4":
-        return <p>View Menu</p>;
+        return <ViewMenu/>;
       case "5":
         return <MessActivities />;
       case "6":
         return <p>Mess Registrations</p>;
       case "7":
-        return <p>Update Menu</p>;
+        return <UpdateMenu/>;
       case "8":
         return <UpdateSemDates />;
       default:

--- a/src/Modules/Mess/components/MessActivities.jsx
+++ b/src/Modules/Mess/components/MessActivities.jsx
@@ -1,0 +1,122 @@
+import {
+  Button,
+  Container,
+  Flex,
+  Grid,
+  Loader,
+  Tabs,
+  Text,
+} from "@mantine/core";
+import { CaretCircleLeft, CaretCircleRight } from "@phosphor-icons/react";
+import { useRef, useState } from "react";
+import classes from "../styles/messModule.module.css";
+
+// Import all the components here
+import UpdateBill from "./UpdateBills.jsx";
+import BillBase from "./BillBaseAndExcelUpload.jsx";
+
+function MessActivities() {
+  const [activeTab, setActiveTab] = useState("0");
+  const tabsListRef = useRef(null);
+
+  const tabItems = [
+    { title: "Bill base and Excel upload" },
+    { title: "Update Bill" },
+    { title: "View Bill" },
+  ];
+
+  const handleTabChange = (direction) => {
+    const newIndex =
+      direction === "next"
+        ? Math.min(+activeTab + 1, tabItems.length - 1)
+        : Math.max(+activeTab - 1, 0);
+    setActiveTab(String(newIndex));
+    tabsListRef.current.scrollBy({
+      left: direction === "next" ? 50 : -50,
+      behavior: "smooth",
+    });
+  };
+
+  // Function to render content based on active tab
+  const renderTabContent = () => {
+    switch (activeTab) {
+      case "0":
+        return <BillBase />;
+      case "1":
+        return <UpdateBill />;
+      case "2":
+        return <UpdateBill />;
+      default:
+        return <Loader />;
+    }
+  };
+
+  return (
+    <>
+      {/* Tab navigation */}
+      <Flex justify="center" align="center" mt="5">
+        {" "}
+        {/* Outer Flex to center horizontally */}
+        <Flex justify="space-between" align="center" gap="1rem" mt="1.5rem">
+          <Button
+            onClick={() => handleTabChange("prev")}
+            variant="default"
+            p={0}
+            style={{ border: "none" }}
+          >
+            <CaretCircleLeft
+              className={classes.fusionCaretCircleIcon}
+              weight="light"
+            />
+          </Button>
+
+          <div className={classes.fusionTabsContainer} ref={tabsListRef}>
+            <Tabs value={activeTab} onChange={setActiveTab}>
+              <Tabs.List style={{ display: "flex", flexWrap: "nowrap" }}>
+                {tabItems.map((item, index) => (
+                  <Tabs.Tab
+                    value={`${index}`}
+                    key={index}
+                    className={
+                      activeTab === `${index}`
+                        ? classes.fusionActiveRecentTab
+                        : ""
+                    }
+                  >
+                    <Flex gap="4px">
+                      <Text>{item.title}</Text>
+                    </Flex>
+                  </Tabs.Tab>
+                ))}
+              </Tabs.List>
+            </Tabs>
+          </div>
+
+          <Button
+            onClick={() => handleTabChange("next")}
+            variant="default"
+            p={0}
+            style={{ border: "none" }}
+          >
+            <CaretCircleRight
+              className={classes.fusionCaretCircleIcon}
+              weight="light"
+            />
+          </Button>
+        </Flex>
+      </Flex>
+
+      {/* Main content */}
+      <Grid>
+        <Container
+          fluid
+          style={{ maxWidth: "600px", margin: "0 auto" }} // Set maxWidth for the container
+        >
+          {renderTabContent()}
+        </Container>
+      </Grid>
+    </>
+  );
+}
+
+export default MessActivities;

--- a/src/Modules/Mess/components/StudentIndex.jsx
+++ b/src/Modules/Mess/components/StudentIndex.jsx
@@ -1,0 +1,134 @@
+import {
+  Button,
+  Container,
+  Flex,
+  Grid,
+  Loader,
+  Tabs,
+  Text,
+} from "@mantine/core";
+import { CaretCircleLeft, CaretCircleRight } from "@phosphor-icons/react";
+import { useRef, useState } from "react";
+import CustomBreadcrumbs from "../../../components/Breadcrumbs.jsx";
+import classes from "../styles/messModule.module.css";
+
+// Import all the components here
+//   import ComplaintForm from "./components/ComplaintForm.jsx";
+
+function Student() {
+  const [activeTab, setActiveTab] = useState("0");
+  const tabsListRef = useRef(null);
+
+  const tabItems = [
+    { title: "View FeedBack | Statistics" },
+    { title: "Respond to rebate requests" },
+    { title: "Reg/Dereg/UpdatePayment Requests" },
+    { title: "View Special Food requests" },
+    { title: "View Menu" },
+    { title: "Mess Activities" },
+    { title: "Mess Registrations" },
+    { title: "Update Menu" },
+    { title: "Update Sem Dates" },
+  ];
+
+  const handleTabChange = (direction) => {
+    const newIndex =
+      direction === "next"
+        ? Math.min(+activeTab + 1, tabItems.length - 1)
+        : Math.max(+activeTab - 1, 0);
+    setActiveTab(String(newIndex));
+    tabsListRef.current.scrollBy({
+      left: direction === "next" ? 50 : -50,
+      behavior: "smooth",
+    });
+  };
+
+  // Function to render content based on active tab
+  const renderTabContent = () => {
+    switch (activeTab) {
+      case "0":
+        return <p>View Feedback | Statistics</p>;
+      case "1":
+        return <p>Respond to rebate requests</p>;
+      case "2":
+        return <p>Reg/Dereg/UpdatePayment Requests</p>;
+      case "3":
+        return <p>View Special Food requests</p>;
+      case "4":
+        return <p>View Menu</p>;
+      case "5":
+        return <p>Mess Activities</p>;
+      case "6":
+        return <p>Mess Registrations</p>;
+      case "7":
+        return <p>Update Menu</p>;
+      case "8":
+        return <p>Update Sem Dates</p>;
+      default:
+        return <Loader />;
+    }
+  };
+
+  return (
+    <>
+      {/* Navbar contents */}
+      <CustomBreadcrumbs />
+      <Flex justify="space-between" align="center" mt="lg">
+        <Flex justify="flex-start" align="center" gap="1rem" mt="1.5rem">
+          <Button
+            onClick={() => handleTabChange("prev")}
+            variant="default"
+            p={0}
+            style={{ border: "none" }}
+          >
+            <CaretCircleLeft
+              className={classes.fusionCaretCircleIcon}
+              weight="light"
+            />
+          </Button>
+
+          <div className={classes.fusionTabsContainer} ref={tabsListRef}>
+            <Tabs value={activeTab} onChange={setActiveTab}>
+              <Tabs.List style={{ display: "flex", flexWrap: "nowrap" }}>
+                {tabItems.map((item, index) => (
+                  <Tabs.Tab
+                    value={`${index}`}
+                    key={index}
+                    className={
+                      activeTab === `${index}`
+                        ? classes.fusionActiveRecentTab
+                        : ""
+                    }
+                  >
+                    <Flex gap="4px">
+                      <Text>{item.title}</Text>
+                    </Flex>
+                  </Tabs.Tab>
+                ))}
+              </Tabs.List>
+            </Tabs>
+          </div>
+
+          <Button
+            onClick={() => handleTabChange("next")}
+            variant="default"
+            p={0}
+            style={{ border: "none" }}
+          >
+            <CaretCircleRight
+              className={classes.fusionCaretCircleIcon}
+              weight="light"
+            />
+          </Button>
+        </Flex>
+      </Flex>
+
+      {/* Main content */}
+      <Grid mt="xl">
+        <Container py="xl">{renderTabContent()}</Container>
+      </Grid>
+    </>
+  );
+}
+
+export default Student;

--- a/src/Modules/Mess/components/UpdateBills.jsx
+++ b/src/Modules/Mess/components/UpdateBills.jsx
@@ -1,0 +1,116 @@
+import React from "react";
+import {
+  TextInput,
+  NumberInput,
+  Select,
+  Button,
+  Container,
+  Title,
+  Paper,
+  Space,
+} from "@mantine/core"; // Import Mantine components
+import { User, CurrencyDollar, Calendar } from "@phosphor-icons/react"; // Import Phosphor Icons
+
+function UpdateBill() {
+  return (
+    <Container
+      size="lg"
+      style={{
+        maxWidth: "800px", // Limit maximum width to 800px
+        width: "570px", // Set the width to a fixed value (e.g., 800px)
+        // marginRight: "800px", // Ensures the right margin is auto, allowing centering effect
+        marginTop: "25px",
+      }} // Container settings
+    >
+      <Paper
+        shadow="md"
+        radius="md"
+        p="xl"
+        withBorder
+        style={{ width: "100%", padding: "30px" }} // Increased padding
+      >
+        <Title order={2} align="center" mb="lg" style={{ color: "#1c7ed6" }}>
+          Update Bill
+        </Title>
+
+        <form method="post" action="/mess/updateBill">
+          {/* Roll Number input */}
+          <TextInput
+            label="Roll No."
+            placeholder="Roll No of Student"
+            id="rollNo"
+            required
+            radius="md"
+            size="md"
+            icon={<User size={20} />}
+            mb="lg"
+          />
+
+          {/* New Amount input */}
+          <NumberInput
+            label="New Amount"
+            placeholder="New amount for this month's bill"
+            id="new_amount"
+            required
+            radius="md"
+            size="md"
+            min={0}
+            step={100}
+            icon={<CurrencyDollar size={20} />}
+            mb="lg"
+          />
+
+          {/* Month select input */}
+          <Select
+            label="Month"
+            id="Month"
+            placeholder="Select month"
+            required
+            radius="md"
+            size="md"
+            icon={<Calendar size={20} />}
+            data={[
+              { value: "january", label: "January" },
+              { value: "february", label: "February" },
+              { value: "march", label: "March" },
+              { value: "april", label: "April" },
+              { value: "may", label: "May" },
+              { value: "june", label: "June" },
+              { value: "july", label: "July" },
+              { value: "august", label: "August" },
+              { value: "september", label: "September" },
+              { value: "october", label: "October" },
+              { value: "november", label: "November" },
+              { value: "december", label: "December" },
+            ]}
+            mb="lg"
+          />
+
+          {/* Year select input */}
+          <Select
+            label="Year"
+            id="Year"
+            placeholder="Select year"
+            required
+            radius="md"
+            size="md"
+            data={[
+              { value: "2023", label: "2023" },
+              { value: "2024", label: "2024" },
+            ]}
+            mb="lg"
+          />
+
+          <Space h="xl" />
+
+          {/* Submit button */}
+          <Button fullWidth size="lg" radius="md" color="blue">
+            Update Bill
+          </Button>
+        </form>
+      </Paper>
+    </Container>
+  );
+}
+
+export default UpdateBill;

--- a/src/Modules/Mess/components/UpdateMenu.jsx
+++ b/src/Modules/Mess/components/UpdateMenu.jsx
@@ -1,0 +1,173 @@
+import React, { useState } from 'react';
+import { Button, Divider, TextInput } from '@mantine/core';
+import classes from '../styles/messModule.module.css'; // Import your CSS module
+
+const UpdateMenu = () => {
+  const initialMenu = {
+    Monday: { breakfast: 'Sprouts, Idli Sambhar, Nariyal Chutney', lunch: 'Sprouts, Idli Sambhar, Nariyal Chutney', dinner: 'Sprouts, Idli Sambhar, Nariyal Chutney' },
+    Tuesday: { breakfast: 'Idli Sambhar, Nariyal Chutney', lunch: 'Idli Sambhar, Nariyal Chutney', dinner: 'Idli Sambhar, Nariyal Chutney' },
+    Wednesday: { breakfast: 'Idli Sambhar, Nariyal Chutney', lunch: 'Idli Sambhar, Nariyal Chutney', dinner: 'Idli Sambhar, Nariyal Chutney' },
+    Thursday: { breakfast: 'Idli Sambhar, Nariyal Chutney', lunch: 'Idli Sambhar, Nariyal Chutney', dinner: 'Idli Sambhar, Nariyal Chutney' },
+    Friday: { breakfast: 'Idli Sambhar, Nariyal Chutney', lunch: 'Idli Sambhar, Nariyal Chutney', dinner: 'Idli Sambhar, Nariyal Chutney' },
+    Saturday: { breakfast: 'Idli Sambhar, Nariyal Chutney', lunch: 'Idli Sambhar, Nariyal Chutney', dinner: 'Idli Sambhar, Nariyal Chutney' },
+    Sunday: { breakfast: 'Idli Sambhar, Nariyal Chutney', lunch: 'Idli Sambhar, Nariyal Chutney', dinner: 'Idli Sambhar, Nariyal Chutney' },
+  };
+
+  const [menu1, setMenu1] = useState({ ...initialMenu, Monday: { breakfast: '', lunch: '', dinner: '' } });
+  const [menu2, setMenu2] = useState(initialMenu);
+  const [activeMess, setActiveMess] = useState('Mess 1');
+
+  const handleChange = (day, mealType, value, messNumber) => {
+    if (messNumber === 'Mess 1') {
+      setMenu1((prevMenu) => ({
+        ...prevMenu,
+        [day]: { ...prevMenu[day], [mealType]: value },
+      }));
+    } else {
+      setMenu2((prevMenu) => ({
+        ...prevMenu,
+        [day]: { ...prevMenu[day], [mealType]: value },
+      }));
+    }
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    console.log('Updated Menu:', activeMess === 'Mess 1' ? menu1 : menu2);
+  };
+
+  const tableStyle = {
+    width: '100%',
+    margin: '20px auto',
+    borderCollapse: 'collapse',
+  };
+
+  const cellStyle = {
+    padding: '8px', 
+    textAlign: 'center', 
+    border: '1px solid #ddd', 
+  };
+
+  const thStyle = {
+    backgroundColor: '#f9f9f9',
+    padding: '8px',
+    textAlign: 'center',
+    border: '1px solid #ddd', 
+  };
+
+  const inputStyle = {
+    width: '100%', 
+    padding: '5px',
+    // border: '1px solid #ccc', // Add thin border for the input
+    backgroundColor: '#f0f4ff',
+    fontSize: '0.9rem', 
+  };
+
+  const buttonStyle = {
+    marginTop: '20px',
+    backgroundColor: '#15abff',
+    color: 'white',
+    padding: '10px 20px',
+    border: 'none',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    display: 'block',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+  };
+
+  const activeTabStyle = {
+    fontWeight: 'bold',
+  backgroundColor: '#15abff13', 
+  cursor: 'pointer',
+  padding: '5px', 
+  borderRadius: '2px', 
+  borderBottom: '2px solid #15abff',
+  color: '#15abff',
+//   boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)', 
+
+  };
+
+  const inactiveTabStyle = {
+    fontWeight: 'normal',
+    borderBottom: '2px solid transparent',
+    cursor: 'pointer',
+    padding: '5px',
+    color: '#aaa',
+  };
+
+  return (
+    <div className={classes.fusionText} style={{ padding: '20px', textAlign: 'center' }}>
+      {/* <Title order={3} className={classes.fusionText}>
+        {activeMess} Menu
+      </Title> */}
+
+      {/* Mess 1 and Mess 2 Tabs */}
+      <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '20px' }}>
+        <div
+          onClick={() => setActiveMess('Mess 1')}
+          style={activeMess === 'Mess 1' ? activeTabStyle : inactiveTabStyle}
+        >
+          Mess 1
+        </div>
+        <div
+          onClick={() => setActiveMess('Mess 2')}
+          style={activeMess === 'Mess 2' ? activeTabStyle : inactiveTabStyle}
+        >
+          Mess 2
+        </div>
+      </div>
+
+      <Divider my="sm" />
+
+      <form onSubmit={handleSubmit}>
+        <table style={tableStyle}>
+          <thead>
+            <tr>
+              <th style={thStyle}>Day</th>
+              <th style={thStyle}>Breakfast</th>
+              <th style={thStyle}>Lunch</th>
+              <th style={thStyle}>Dinner</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Object.keys(activeMess === 'Mess 1' ? menu1 : menu2).map((day) => (
+              <tr key={day}>
+                <td style={cellStyle}>{day}</td>
+                <td style={cellStyle}>
+                  <TextInput
+                    value={activeMess === 'Mess 1' ? menu1[day].breakfast : menu2[day].breakfast}
+                    onChange={(e) => handleChange(day, 'breakfast', e.target.value, activeMess)}
+                    placeholder="Breakfast"
+                    style={inputStyle}
+                  />
+                </td>
+                <td style={cellStyle}>
+                  <TextInput
+                    value={activeMess === 'Mess 1' ? menu1[day].lunch : menu2[day].lunch}
+                    onChange={(e) => handleChange(day, 'lunch', e.target.value, activeMess)}
+                    placeholder="Lunch"
+                    style={inputStyle}
+                  />
+                </td>
+                <td style={cellStyle}>
+                  <TextInput
+                    value={activeMess === 'Mess 1' ? menu1[day].dinner : menu2[day].dinner}
+                    onChange={(e) => handleChange(day, 'dinner', e.target.value, activeMess)}
+                    placeholder="Dinner"
+                    style={inputStyle}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <Button type="submit" style={buttonStyle}>
+          Save
+        </Button>
+      </form>
+    </div>
+  );
+};
+
+export default UpdateMenu;

--- a/src/Modules/Mess/components/UpdateSemesterDates.jsx
+++ b/src/Modules/Mess/components/UpdateSemesterDates.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+function update_sem_dates() {
+  return <div>update_sem_dates</div>;
+}
+
+export default update_sem_dates;

--- a/src/Modules/Mess/components/ViewMenu.jsx
+++ b/src/Modules/Mess/components/ViewMenu.jsx
@@ -1,0 +1,148 @@
+// ViewMenu.jsx
+import React, { useState } from 'react';
+import { Divider, Button } from '@mantine/core';
+import { IconDownload } from '@tabler/icons-react';  // Importing the download icon from Mantine
+import classes from '../styles/messModule.module.css'; // Importing the provided CSS module
+
+const ViewMenu = () => {
+  // Define separate menus for Mess-1 and Mess-2
+  const menuMess1 = {
+    Monday: { breakfast: 'Sprouts, Idli Sambhar, Nariyal Chutney', lunch: 'Aaloo Jeera Sabji, Dal Makhni, Jeera Rice', dinner: 'Aaloo Jeera Sabji, Dal Makhni, Jeera Rice, Chapati, Suji halwa' },
+    Tuesday: { breakfast: 'Sprouts, Idli Sambhar, Nariyal Chutney', lunch: 'Aaloo Jeera Sabji, Dal Makhni, Jeera Rice', dinner: 'Aaloo Jeera Sabji, Dal Makhni, Jeera Rice, Chapati, Suji halwa' },
+    Wednesday: { breakfast: 'Sprouts, Idli Sambhar, Nariyal Chutney', lunch: 'Aaloo Jeera Sabji, Dal Makhni, Jeera Rice', dinner: 'Aaloo Jeera Sabji, Dal Makhni, Jeera Rice, Chapati, Suji halwa' },
+    Thursday: { breakfast: 'Sprouts, Idli Sambhar, Nariyal Chutney', lunch: 'Aaloo Jeera Sabji, Dal Makhni, Jeera Rice', dinner: 'Aaloo Jeera Sabji, Dal Makhni, Jeera Rice, Chapati, Suji halwa' },
+    Friday: { breakfast: 'Sprouts, Idli Sambhar, Nariyal Chutney', lunch: 'Aaloo Jeera Sabji, Dal Makhni, Jeera Rice', dinner: 'Aaloo Jeera Sabji, Dal Makhni, Jeera Rice, Chapati, Suji halwa' },
+    Saturday: { breakfast: 'Sprouts, Idli Sambhar, Nariyal Chutney', lunch: 'Aaloo Jeera Sabji, Dal Makhni, Jeera Rice', dinner: 'Aaloo Jeera Sabji, Dal Makhni, Jeera Rice, Chapati, Suji halwa' },
+    Sunday: { breakfast: 'Sprouts, Idli Sambhar, Nariyal Chutney', lunch: 'Aaloo Jeera Sabji, Dal Makhni, Jeera Rice', dinner: 'Aaloo Jeera Sabji, Dal Makhni, Jeera Rice, Chapati, Suji halwa' },
+  };
+
+  const menuMess2 = {
+    Monday: { breakfast: 'Poha, Jalebi, Tea', lunch: 'Rajma, Rice, Chapati', dinner: 'Shahi Paneer, Dal Tadka, Chapati' },
+    Tuesday: { breakfast: 'Puri Bhaji, Chai', lunch: 'Chhole Bhature, Rice', dinner: 'Mixed Veg, Dal Fry, Jeera Rice' },
+    Wednesday: { breakfast: 'Upma, Sambhar, Chutney', lunch: 'Chana Masala, Rice, Chapati', dinner: 'Matar Paneer, Dal, Jeera Rice' },
+    Thursday: { breakfast: 'Aloo Paratha, Curd', lunch: 'Kadhi Pakora, Rice, Chapati', dinner: 'Paneer Butter Masala, Dal, Chapati' },
+    Friday: { breakfast: 'Bread Butter, Chai', lunch: 'Lauki Sabji, Rice, Chapati', dinner: 'Baingan Bharta, Dal Makhni, Jeera Rice' },
+    Saturday: { breakfast: 'Dosa, Sambhar, Chutney', lunch: 'Rajma Rice, Chapati', dinner: 'Aloo Gobi, Dal Fry, Jeera Rice' },
+    Sunday: { breakfast: 'Pancakes, Syrup', lunch: 'Chole, Rice, Chapati', dinner: 'Malai Kofta, Dal Makhni, Jeera Rice' },
+  };
+
+  const [activeMess, setActiveMess] = useState('Mess 1');
+
+  // Choose menu based on activeMess
+  const menu = activeMess === 'Mess 1' ? menuMess1 : menuMess2;
+
+  const tableStyle = {
+    width: '100%',
+    margin: '20px auto',
+    borderCollapse: 'collapse',
+  };
+
+  const cellStyle = {
+    padding: '10px',
+    textAlign: 'center',
+    border: '1px solid #ddd',
+  };
+
+  const thStyle = {
+    backgroundColor: '#f9f9f9',
+    padding: '10px',
+    textAlign: 'center',
+    border: '1px solid #ddd',
+    fontWeight: 'bold',
+  };
+
+  const activeTabStyle = {
+    fontWeight: 'bold',
+    backgroundColor: '#15abff13', 
+    cursor: 'pointer',
+    padding: '5px', 
+    borderRadius: '2px', 
+    borderBottom: '2px solid #15abff',
+    color: '#15abff',
+  };
+
+  const inactiveTabStyle = {
+    fontWeight: 'normal',
+    borderBottom: '2px solid transparent',
+    cursor: 'pointer',
+    padding: '5px',
+    color: '#aaa',
+  };
+
+  const downloadMenu = () => {
+    let menuContent = `Menu for ${activeMess}\n\n`;
+    for (const day in menu) {
+      menuContent += `${day}:\n`;
+      menuContent += `Breakfast: ${menu[day].breakfast}\n`;
+      menuContent += `Lunch: ${menu[day].lunch}\n`;
+      menuContent += `Dinner: ${menu[day].dinner}\n\n`;
+    }
+
+    const blob = new Blob([menuContent], { type: 'text/plain' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = `${activeMess}-menu.txt`;
+    link.click();
+  };
+
+  return (
+    <div className={classes.fusionText} style={{ padding: '20px', textAlign: 'center' }}>
+      {/* Mess 1 and Mess 2 Tabs */}
+      <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '20px' }}>
+        <div
+          onClick={() => setActiveMess('Mess 1')}
+          style={activeMess === 'Mess 1' ? activeTabStyle : inactiveTabStyle}
+        >
+          Mess-1
+        </div>
+        <div
+          onClick={() => setActiveMess('Mess 2')}
+          style={activeMess === 'Mess 2' ? activeTabStyle : inactiveTabStyle}
+        >
+          Mess-2
+        </div>
+      </div>
+
+      <Divider my="sm" />
+
+      <table style={tableStyle}>
+        <thead>
+          <tr>
+            <th style={thStyle}>Day</th>
+            <th style={thStyle}>Breakfast</th>
+            <th style={thStyle}>Lunch</th>
+            <th style={thStyle}>Dinner</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.keys(menu).map((day) => (
+            <tr key={day}>
+              <td style={cellStyle}>{day}</td>
+              <td style={cellStyle}>{menu[day].breakfast}</td>
+              <td style={cellStyle}>{menu[day].lunch}</td>
+              <td style={cellStyle}>{menu[day].dinner}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {/* Download Button with Icon */}
+      <Button
+        onClick={downloadMenu}
+        style={{
+          marginTop: '20px',
+          backgroundColor: '#15abff',
+          color: 'white',
+          padding: '5px 20px',
+          border: 'none',
+          borderRadius: '4px',
+          cursor: 'pointer',
+        }}
+      >
+        <IconDownload size={24} />
+      </Button>
+    </div>
+  );
+};
+
+export default ViewMenu;

--- a/src/Modules/Mess/components/WardenIndex.jsx
+++ b/src/Modules/Mess/components/WardenIndex.jsx
@@ -1,0 +1,119 @@
+import {
+  Button,
+  Container,
+  Flex,
+  Grid,
+  Loader,
+  Tabs,
+  Text,
+} from "@mantine/core";
+import { CaretCircleLeft, CaretCircleRight } from "@phosphor-icons/react";
+import { useRef, useState } from "react";
+import CustomBreadcrumbs from "../../../components/Breadcrumbs.jsx";
+import classes from "../styles/messModule.module.css";
+
+// Import all the components here
+//   import ComplaintForm from "./components/ComplaintForm.jsx";
+
+function Warden() {
+  const [activeTab, setActiveTab] = useState("0");
+  const tabsListRef = useRef(null);
+
+  const tabItems = [
+    { title: "View FeedBack | Statistics" },
+    { title: "View Menu" },
+    { title: "view Bills" },
+    { title: "View Registrations" },
+  ];
+
+  const handleTabChange = (direction) => {
+    const newIndex =
+      direction === "next"
+        ? Math.min(+activeTab + 1, tabItems.length - 1)
+        : Math.max(+activeTab - 1, 0);
+    setActiveTab(String(newIndex));
+    tabsListRef.current.scrollBy({
+      left: direction === "next" ? 50 : -50,
+      behavior: "smooth",
+    });
+  };
+
+  // Function to render content based on active tab
+  const renderTabContent = () => {
+    switch (activeTab) {
+      case "0":
+        return <p>View Feedback | Statistics</p>;
+      case "1":
+        return <p>View Menu</p>;
+      case "2":
+        return <p>View Bills</p>;
+      case "3":
+        return <p>View Registrations</p>;
+      default:
+        return <Loader />;
+    }
+  };
+
+  return (
+    <>
+      {/* Navbar contents */}
+      <CustomBreadcrumbs />
+      <Flex justify="space-between" align="center" mt="lg">
+        <Flex justify="flex-start" align="center" gap="1rem" mt="1.5rem">
+          <Button
+            onClick={() => handleTabChange("prev")}
+            variant="default"
+            p={0}
+            style={{ border: "none" }}
+          >
+            <CaretCircleLeft
+              className={classes.fusionCaretCircleIcon}
+              weight="light"
+            />
+          </Button>
+
+          <div className={classes.fusionTabsContainer} ref={tabsListRef}>
+            <Tabs value={activeTab} onChange={setActiveTab}>
+              <Tabs.List style={{ display: "flex", flexWrap: "nowrap" }}>
+                {tabItems.map((item, index) => (
+                  <Tabs.Tab
+                    value={`${index}`}
+                    key={index}
+                    className={
+                      activeTab === `${index}`
+                        ? classes.fusionActiveRecentTab
+                        : ""
+                    }
+                  >
+                    <Flex gap="4px">
+                      <Text>{item.title}</Text>
+                    </Flex>
+                  </Tabs.Tab>
+                ))}
+              </Tabs.List>
+            </Tabs>
+          </div>
+
+          <Button
+            onClick={() => handleTabChange("next")}
+            variant="default"
+            p={0}
+            style={{ border: "none" }}
+          >
+            <CaretCircleRight
+              className={classes.fusionCaretCircleIcon}
+              weight="light"
+            />
+          </Button>
+        </Flex>
+      </Flex>
+
+      {/* Main content */}
+      <Grid mt="xl">
+        <Container py="xl">{renderTabContent()}</Container>
+      </Grid>
+    </>
+  );
+}
+
+export default Warden;

--- a/src/Modules/Mess/messContent.jsx
+++ b/src/Modules/Mess/messContent.jsx
@@ -1,5 +1,0 @@
-function MessContent() {
-  return <div>MessContent</div>;
-}
-
-export default MessContent;

--- a/src/Modules/Mess/pages/index.jsx
+++ b/src/Modules/Mess/pages/index.jsx
@@ -1,0 +1,22 @@
+import { useSelector } from "react-redux";
+import { Loader } from "@mantine/core";
+import Caretaker from "../components/CaretakerIndex";
+import Warden from "../components/WardenIndex";
+import Student from "../components/StudentIndex";
+
+function MessPage() {
+  const role = useSelector((state) => state.user.role);
+  console.log(role);
+  switch (role) {
+    case "mess_manager":
+      return <Caretaker />;
+    case "student":
+      return <Student />;
+    case "mess_warden":
+      return <Warden />;
+    default:
+      return <Loader />;
+  }
+}
+
+export default MessPage;

--- a/src/Modules/Mess/styles/messModule.module.css
+++ b/src/Modules/Mess/styles/messModule.module.css
@@ -1,0 +1,52 @@
+.fusionText {
+    font-size: 1rem;
+    @media (min-width: mantine-breakpoint-md) {
+      font-size: 1.5rem;
+    }
+  }
+  
+  .fusionCaretCircleIcon {
+    font-size: 2rem;
+    @media (min-width: mantine-breakpoint-md) {
+      font-size: 1.5rem;
+    }
+  }
+  
+  .fusionCaretIcon {
+    font-size: 1rem;
+    @media (min-width: mantine-breakpoint-md) {
+      font-size: 1.25rem;
+    }
+  }
+  
+  .fusionActiveRecentTab {
+    background-color: #15abff13;
+    color: #15abff;
+    font-weight: 800;
+    border-radius: 4px;
+  }
+  
+  .fusionTabsContainer {
+    flex-shrink: 1;
+    max-width: 80vw;
+    overflow-x: auto;
+    -ms-overflow-style: none;
+  }
+  
+  .fusionTabsContainer::-webkit-scrollbar {
+    display: none;
+  }
+  
+  .selectinputs {
+      background-color: #15abff20;
+      border-color: #15abff4d;
+  }
+  
+  .selectinputs::placeholder {
+      color: #15abff;
+      font-weight: 600;
+  }
+  
+  .selectoptions:hover {
+    background-color: #15abff10; /* Transparent blue hover background */
+  }

--- a/src/Modules/Mess/styles/messModule.module.css
+++ b/src/Modules/Mess/styles/messModule.module.css
@@ -45,8 +45,8 @@
   .selectinputs::placeholder {
       color: #15abff;
       font-weight: 600;
-  }
+  } 
   
   .selectoptions:hover {
     background-color: #15abff10; /* Transparent blue hover background */
-  }
+  }   

--- a/src/components/sidebarContent.jsx
+++ b/src/components/sidebarContent.jsx
@@ -63,7 +63,7 @@ const Modules = [
     label: "Mess Management",
     id: "mess_management",
     icon: <MessIcon size={18} />,
-    url: "/",
+    url: "/mess",
   },
   {
     label: "Visitor's Hostel",


### PR DESCRIPTION
## Overview

1. This PR does the following: Adds two new pages, UpdateMenu and ViewMenu, for caretakers to manage the mess meal schedules.

## Key Features:

- [x] ViewMenu: Allows caretakers to view the daily meal schedule for Mess 1 and Mess 2.
- [x] UpdateMenu: Provides functionality for caretakers to update the meal schedule for each day and meal type (breakfast, lunch, dinner) for both Mess 1 and Mess 2.
- [x] Switch between Mess 1 and Mess 2 for viewing and updating menus.
- [x] Editable input fields on the UpdateMenu page for modifying the meal schedule.
- [x] Download functionality on the ViewMenu page to export the menu as a .txt file.
